### PR TITLE
Updating function renaming interface

### DIFF
--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -92,7 +92,7 @@ module FFIGenerate
     end
 
     def read_declaration(declaration_cursor, comment)
-      name = read_name(declaration_cursor)
+      name = read_name(declaration_cursor, :is_function)
 
       declaration = case declaration_cursor.kind
       when :enum_decl

--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -503,17 +503,10 @@ module FFIGenerate
     #
     def transform_by_renaming_imported_function_names(func_name)
       if @rename_imported_functions && @rename_imported_functions.is_a?(Hash)
-        if @rename_imported_functions[:when_matches_regex].is_a?(Array)
-          @rename_imported_functions[:when_matches_regex].each do |operation|
-            if operation.is_a?(Hash)
-              func_name = transform_function_name(func_name, operation)
-            end
-          end
-        end
-        if @rename_imported_functions[:when_func_name_matches_regex].is_a?(Array)
-          @rename_imported_functions[:when_func_name_matches_regex].each do |operation|
-            if operation.is_a?(Hash)
-              func_name = transform_function_name(func_name, operation)
+        [:when_matches_regex, :when_func_name_matches_regex].each do |operation_type|
+          if @rename_imported_functions[operation_type].is_a?(Array)
+            @rename_imported_functions[operation_type].each do |operation|
+              func_name = transform_function_name(func_name, operation) if operation.is_a?(Hash)
             end
           end
         end

--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -10,7 +10,9 @@ module FFIGenerate
                 :output,
                 :translation_unit,
                 :declarations,
-                :rename_imported_functions
+                :rename_imported_functions,
+                :prefixes,  # TODO: deprecated
+                :suffixes   # TODO: deprecated
 
     def initialize(options = {})
       @module_name   = options[:module_name] || fail("No module name given.")
@@ -23,8 +25,8 @@ module FFIGenerate
       @translation_unit = nil
       @declarations = nil
       @rename_imported_functions = options[:rename_imported_functions]
-      # @prefixes      = options.fetch(:prefixes, [])
-      # @suffixes      = options.fetch(:suffixes, [])
+      @prefixes      = options.fetch(:prefixes, []) # TODO: deprecated
+      @suffixes      = options.fetch(:suffixes, []) # TODO: deprecated
     end
 
     def generate
@@ -453,6 +455,8 @@ module FFIGenerate
       source = source.spelling if source.is_a?(Clang::Cursor)
       return nil if source.empty?
       trimmed = transform_by_renaming_imported_function_names(source)
+      trimmed = trimmed.sub(/^(#{@prefixes.join('|')})/, '')
+      trimmed = trimmed.sub(/(#{@suffixes.join('|')})$/, '')
       parts = trimmed.split(/_|(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).reject(&:empty?)
       Name.new(parts, source)
     end

--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -487,14 +487,19 @@ module FFIGenerate
     # },
     #
     # Which if the C/C++ header has functions named:
-    # - example_lib_call_1
-    # - has_a_thing
-    # - my_name_to_match
+    #  - example_lib_call_1
+    #  - has_a_thing
+    #  - my_name_to_match
     #
     # They will transform to ruby functions named:
-    # - f__lib_call_1
-    # - rb_has_a_thing?
-    # - __my_custom_name
+    #  - f__lib_call_1
+    #  - rb_has_a_thing?
+    #  - __my_custom_name
+    #
+    # Order of transform operations is:
+    #  1. replace_with
+    #  2. append_to_start
+    #  3. append_to_end
     #
     def transform_by_renaming_imported_function_names(func_name)
       if @rename_imported_functions && @rename_imported_functions.is_a?(Hash)
@@ -524,6 +529,10 @@ module FFIGenerate
       replace_with = operation.keys.include?(:replace_with)
 
       if found_match
+        # *Update the docs if you change the ordering of these operations* which should be:
+        #  1. replace_with
+        #  2. append_to_start
+        #  3. append_to_end
         func_name = func_name.gsub(operation[:regex_pattern], operation[:replace_with]) if replace_with
         func_name = "#{operation[:append_to_start]}#{func_name}" if append_to_start
         func_name += operation[:append_to_end] if append_to_end

--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -496,15 +496,15 @@ module FFIGenerate
     # - __my_custom_name
     #
     def transform_by_renaming_imported_function_names(func_name)
-      if @rename_imported_functions && @rename_imported_functions.is_a? Hash
-        if @rename_imported_functions[:when_matches_regex].is_a? Array
+      if @rename_imported_functions && @rename_imported_functions.is_a?(Hash)
+        if @rename_imported_functions[:when_matches_regex].is_a?(Array)
           @rename_imported_functions[:when_matches_regex].each do |operation|
             if operation.is_a? Hash
               func_name = transform_function_name(func_name, operation)
             end
           end
         end
-        if @rename_imported_functions[:when_func_name_matches_regex].is_a? Array
+        if @rename_imported_functions[:when_func_name_matches_regex].is_a?(Array)
           @rename_imported_functions[:when_func_name_matches_regex].each do |operation|
             if operation.is_a? Hash
               func_name = transform_function_name(func_name, operation)

--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -457,7 +457,8 @@ module FFIGenerate
       trimmed = transform_by_renaming_imported_function_names(source)
       trimmed = trimmed.sub(/^(#{@prefixes.join('|')})/, '')
       trimmed = trimmed.sub(/(#{@suffixes.join('|')})$/, '')
-      parts = trimmed.split(/_|(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).reject(&:empty?)
+      # parts = trimmed.split(/_|(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).reject(&:empty?)
+      parts = trimmed.split(/_/).reject(&:empty?)
       Name.new(parts, source)
     end
 
@@ -520,12 +521,12 @@ module FFIGenerate
       found_match = func_name[operation[:regex_pattern]]
       append_to_start = !operation[:append_to_start].to_s.empty?
       append_to_end = !operation[:append_to_end].to_s.empty?
-      replace_with = !operation[:replace_with].to_s.empty?
+      replace_with = operation.keys.include?(:replace_with)
 
       if found_match
+        func_name = func_name.gsub(operation[:regex_pattern], operation[:replace_with]) if replace_with
         func_name = "#{operation[:append_to_start]}#{func_name}" if append_to_start
         func_name += operation[:append_to_end] if append_to_end
-        func_name = func_name.gsub(operation[:regex_pattern], operation[:replace_with]) if replace_with
       end
 
       func_name

--- a/lib/ffi_generator/generator.rb
+++ b/lib/ffi_generator/generator.rb
@@ -457,7 +457,7 @@ module FFIGenerate
       trimmed = transform_by_renaming_imported_function_names(source)
       trimmed = trimmed.sub(/^(#{@prefixes.join('|')})/, '')
       trimmed = trimmed.sub(/(#{@suffixes.join('|')})$/, '')
-      # parts = trimmed.split(/_|(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).reject(&:empty?)
+      # parts = trimmed.split(/_|(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).reject(&:empty?) # TODO: deprecate with prefixes
       parts = trimmed.split(/_/).reject(&:empty?)
       Name.new(parts, source)
     end
@@ -505,14 +505,14 @@ module FFIGenerate
       if @rename_imported_functions && @rename_imported_functions.is_a?(Hash)
         if @rename_imported_functions[:when_matches_regex].is_a?(Array)
           @rename_imported_functions[:when_matches_regex].each do |operation|
-            if operation.is_a? Hash
+            if operation.is_a?(Hash)
               func_name = transform_function_name(func_name, operation)
             end
           end
         end
         if @rename_imported_functions[:when_func_name_matches_regex].is_a?(Array)
           @rename_imported_functions[:when_func_name_matches_regex].each do |operation|
-            if operation.is_a? Hash
+            if operation.is_a?(Hash)
               func_name = transform_function_name(func_name, operation)
             end
           end

--- a/lib/ffi_generator/generator/writer.rb
+++ b/lib/ffi_generator/generator/writer.rb
@@ -28,7 +28,8 @@ module FFIGenerate
 
       def puts(*lines)
         lines.each do |line|
-          @output << "#{@current_indentation}#{line}\n"
+          @output << "#{@current_indentation}#{line}" unless line.strip.empty?
+          @output << "\n"
         end
       end
 


### PR DESCRIPTION
- [x] Updated interface to support `when_func_name_matches_regex` to more dynamically change imported function names.
- [x] Cleanup generators extra whitespace littering all generated files with 2 spaces (when no content)